### PR TITLE
BaseAPI: Move call to toJSON for models into conditional code

### DIFF
--- a/apis/base.es6.js
+++ b/apis/base.es6.js
@@ -168,6 +168,7 @@ class BaseAPI {
         if (!valid) {
           return reject(new ValidationError(this.api, model));
         }
+        model = model.toJSON();
       } else {
         model = data;
       }
@@ -184,7 +185,7 @@ class BaseAPI {
         s.set('Authorization', 'bearer ' + this.config.token);
       }
 
-      s.send(model.toJSON()).end((err, res) => {
+      s.send(model).end((err, res) => {
         const fakeReq = {
           origin,
           path,


### PR DESCRIPTION
this lets us call save without a model for endpoints where one is not needed.