### PR TITLE
Fix model validation with optional keys

### DIFF
--- a/models/base.es6.js
+++ b/models/base.es6.js
@@ -39,7 +39,7 @@ class Base {
 
     for (p in this.props) {
       // Optionally, send in an array of keys to validate
-      if (keys && keys.includes(p)) {
+      if (!keys || keys.includes(p)) {
         if (validators[p] && !validators[p](this.props[p])) {
           invalid.push(p);
         }


### PR DESCRIPTION
Tests were broken by adding optional key validation. This patches
validate to run validators as expected when there aren’t specific keys
passed in.